### PR TITLE
Instruction update for new API requirement.

### DIFF
--- a/POLYGLOT_CONFIG.md
+++ b/POLYGLOT_CONFIG.md
@@ -35,6 +35,7 @@ Restart node server and press authenticate (should only be needed first time).
 On authentication, you will need to grant the correct API permissions.  At a minimum the two following permissions need to be granted.
 - Vehicle Information
 - Vehicle Commands
+- Vehicle Location (new permission required if you set LOCATION_EN to true)
 
 If permissions need to be updated or changed, log into tesla.com and manage your third party apps.  These settings are in the Tesla website under Account Settings -> Security -> Third Party Apps -> Tesla Plugin for IoX.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Restart node server and press authenticate (should only be needed first time).
 On authentication, you will need to grant the correct API permissions.  At a minimum the two following permissions need to be granted.
 - Vehicle Information
 - Vehicle Commands
+- Vehicle Location (new permission required if you set LOCATION_EN to true)
 
 If permissions need to be updated or changed, log into tesla.com and manage your third party apps.  These settings are in the Tesla website under Account Settings -> Security -> Third Party Apps -> Tesla Plugin for IoX.
 


### PR DESCRIPTION
Enable the Scope: To use this scope, simply enable "vehicle_location" scope on your application from the Developer UI and include it in both /authorize and /token requests. Starting 1st January 2025, explicit user consent will be required for vehicle location access, so be sure to update your application accordingly and request additional consent from your users.